### PR TITLE
Export unpad as a global

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,12 +49,7 @@ module.exports = function (grunt) {
       },
       unpad: {
         files: {
-          'dist/pkcs7.unpad.js': 'lib/unpad.js'
-        },
-        options: {
-          bundleOptions: {
-            standalone: 'pkcs7.unpad'
-          }
+          'dist/pkcs7.unpad.js': 'lib/unpad.export.js'
         }
       }
     },

--- a/dist/pkcs7.unpad.js
+++ b/dist/pkcs7.unpad.js
@@ -1,4 +1,11 @@
-!function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),(f.pkcs7||(f.pkcs7={})).unpad=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(_dereq_,module,exports){
+(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+(function (global){
+global.window.pkcs7 = {
+  unpad: require('./unpad')
+};
+
+}).call(this,typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+},{"./unpad":2}],2:[function(require,module,exports){
 /*
  * pkcs7.unpad
  * https://github.com/brightcove/pkcs7
@@ -19,6 +26,4 @@ module.exports = function unpad(padded) {
   return padded.subarray(0, padded.byteLength - padded[padded.byteLength - 1]);
 };
 
-},{}]},{},[1])
-(1)
-});
+},{}]},{},[1]);

--- a/lib/unpad.export.js
+++ b/lib/unpad.export.js
@@ -1,0 +1,3 @@
+global.window.pkcs7 = {
+  unpad: require('./unpad')
+};


### PR DESCRIPTION
Mixed UMD and global-style dependencies can cause errors for downstream browser consumers of this library. If you're in a UMD/browserify/node environment, standard dist/ file or the sources themselves can be used to pull in pkcs7. If you _need_ pkcs7 to be useful global-style (even in require() is defined in this environment), you can use pkcs7.unpad.js.
